### PR TITLE
initial implementation of folder caching

### DIFF
--- a/R/demo_SDdata.R
+++ b/R/demo_SDdata.R
@@ -142,7 +142,13 @@ get_demo_SDdata <- function(
     zipname <- allz[zipind]
     message(sprintf("caching %s", zipname))
     fpath <- allurls[zipind]
-    loc <- BiocFileCache::bfcadd(cache, rname=zipname, fpath=fpath, rtype="web")
+    # loc <- BiocFileCache::bfcadd(cache, rname=zipname, fpath=fpath, rtype="web")
+    # loc <- bfcadd_folder(cache, rname=zipname, fpath=fpath, rtype="web")
+    loc <- .bfc_cached_unzip_dir(
+      cache = cache,
+      rname = paste0("SpatialData.data:unzipped:", zipname),
+      fpath = fpath
+    )
   }
   
   # single pattern, length(ind) == 1
@@ -156,16 +162,16 @@ get_demo_SDdata <- function(
   # unzip (convert to zarr if needed using spatialdata-io)
   # and return to target
   if(source == bucket_path("biocOSN_Xenium")){
-    dir.create(td <- tempfile()) # can't use target'
-    utils::unzip(loc, exdir=td)  # manufacturer output
+    # dir.create(td <- tempfile()) # can't use target'
+    # utils::unzip(loc, exdir=td)  # manufacturer output
     if (dir.exists(target)) 
       warning("target exists")
-    use_sdio("xenium", srcdir=td, dest=target) # zarr in target
+    use_sdio("xenium", srcdir=loc, dest=target) # zarr in target
     return(target)
   } else {
-    dir.create(td <- target)
-    utils::unzip(loc, exdir=td)
-    return(dir(td, full.names=TRUE)) 
+    # dir.create(td <- target)
+    # utils::unzip(loc, exdir=td)
+    return(dir(loc, full.names=TRUE)) 
   }
 }
 
@@ -178,7 +184,8 @@ get_demo_SDdata <- function(
   target=tempfile(), 
   source=bucket_path("biocOSN")
 ) {
-  SpatialData::readSpatialData(
+  start <- proc.time()
+  sd <- SpatialData::readSpatialData(
     get_demo_SDdata(
       patt = patt,
       cache = cache,
@@ -186,6 +193,8 @@ get_demo_SDdata <- function(
       source = source
     )
   )
+  print(proc.time() - start)
+  sd
 }
 
 .pattern_not_unique <- function(patt) {
@@ -224,6 +233,80 @@ get_demo_SDdata <- function(
   fp <- file.path(source, zipname)
   message(sprintf("retrieving from %s, caching, and returning path", source))
   BiocFileCache::bfcadd(cache, rname=zipname, fpath=fp, rtype="web")
+}
+
+.bfc_cached_unzip_dir <- function(
+    cache,
+    rname,
+    fpath,
+    ext = "_unzipped",
+    fname = "unique"
+) {
+  q <- BiocFileCache::bfcquery(
+    cache,
+    rname,
+    field = "rname",
+    exact = TRUE
+  )
+  
+  if (nrow(q) > 1L) {
+    stop("Multiple BiocFileCache records found for: ", rname)
+  }
+  
+  if (nrow(q) == 0L) {
+    rid <- names(BiocFileCache::bfcadd(
+      cache,
+      rname = rname,
+      fpath = fpath,
+      rtype = "web",
+      download = FALSE,
+      ext = ext,
+      fname = fname
+    ))
+  } else {
+    rid <- q$rid[[1]]
+  }
+  
+  out <- unname(BiocFileCache::bfcrpath(cache, rids = rid))
+  stale <- BiocFileCache::bfcneedsupdate(cache, rid)
+  
+  if (!dir.exists(out) || isTRUE(stale)) {
+    BiocFileCache::bfcdownload(
+      cache,
+      rid,
+      ask = FALSE,
+      FUN = .unzip_to_dir
+    )
+    out <- unname(BiocFileCache::bfcrpath(cache, rids = rid))
+  }
+  
+  out
+}
+
+.unzip_to_dir <- function(from, to) {
+  if (dir.exists(to)) {
+    unlink(to, recursive = TRUE, force = TRUE)
+  } else if (file.exists(to)) {
+    unlink(to, force = TRUE)
+  }
+  
+  ok <- dir.create(to, recursive = TRUE, showWarnings = FALSE)
+  if (!ok && !dir.exists(to)) {
+    return("could not create extraction directory")
+  }
+  
+  start <- proc.time()
+  ans <- tryCatch(
+    utils::unzip(from, exdir = to),
+    error = function(e) e
+  )
+  print(proc.time() - start)
+  
+  if (inherits(ans, "error")) {
+    return(conditionMessage(ans))
+  }
+  
+  TRUE
 }
 
 ####

--- a/inst/scripts/cache_folder_test.R
+++ b/inst/scripts/cache_folder_test.R
@@ -1,0 +1,11 @@
+cache <- BiocFileCache::BiocFileCache()
+fpath <- "https://s3.embl.de/spatialdata/spatialdata-sandbox/visium_spatialdata_0.7.1.zip"
+zipname <- "visium_spatialdata_0.7.1.zip"
+loc <- BiocFileCache::bfcadd(cache, rname=zipname, fpath=fpath, rtype="web")
+td_old <- file.path(tempdir(), tools::file_path_sans_ext(zipname))
+unzip(loc, exdir = td_old)
+td_old <- dir(td_old, full.names = TRUE)
+td <- file.path(tempdir(), paste0(tools::file_path_sans_ext(zipname), ".zarr"))
+dir.create(td)
+file.rename(td_old, td)
+loc <- BiocFileCache::bfcadd(cache, rname=basename(td), fpath=td)


### PR DESCRIPTION
Caching folder instead of the files, still a draft. 

However, some initial tests show that the bottleneck is mostly due to reading but not unzipping: 

```
> sd <- SpaceMHelaniH3T3()
caching spacem_helanih3t3_spatialdata_0.7.1.zip
   user  system elapsed 
  0.106   0.282   0.567 

   user  system elapsed 
 43.793   6.305  68.981 
> sd <- SpaceMHelaniH3T3()
   user  system elapsed 
 44.261   6.238  68.456
```

Fixes #15 